### PR TITLE
Set default weight for newly added items

### DIFF
--- a/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
+++ b/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
@@ -13,6 +13,7 @@ namespace RandomElementsSystem.Editor
         protected bool _isEqualWeightForAllItems;
         protected SerializedProperty _selectableValues;
         private int _previousArraySize;
+        private bool _isInitialized;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -131,7 +132,14 @@ namespace RandomElementsSystem.Editor
 
             var currentSize = _selectableValues.arraySize;
 
-            if (currentSize == 1)
+            if (!_isInitialized)
+            {
+                _isInitialized = true;
+                _previousArraySize = currentSize;
+                return;
+            }
+
+            if (currentSize == 1 && _previousArraySize == 0)
             {
                 var element = _selectableValues.GetArrayElementAtIndex(0);
                 var weight = element.FindPropertyRelative("_weight");
@@ -153,5 +161,4 @@ namespace RandomElementsSystem.Editor
         }
     }
 }
-
 #endif

--- a/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
+++ b/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
@@ -1,6 +1,7 @@
 #if UNITY_EDITOR
 
 using RandomElementsSystem.Types;
+using System.Collections.Generic;
 
 using UnityEditor;
 using UnityEngine;
@@ -12,6 +13,7 @@ namespace RandomElementsSystem.Editor
     {
         protected bool _isEqualWeightForAllItems;
         protected SerializedProperty _selectableValues;
+        protected readonly Dictionary<string, int> _propertyToArraySize = new();
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -21,6 +23,7 @@ namespace RandomElementsSystem.Editor
             _isEqualWeightForAllItems = isEqualWeightForAllItems.boolValue;
 
             _selectableValues = property.FindPropertyRelative("_selectableValues");
+            SetDefaultWeightForNewElements(property);
 
             if (property.isExpanded && _selectableValues.isExpanded)
             {
@@ -118,6 +121,32 @@ namespace RandomElementsSystem.Editor
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
             return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        private void SetDefaultWeightForNewElements(SerializedProperty property)
+        {
+            if (_selectableValues == null)
+            {
+                return;
+            }
+
+            var propertyKey = property.propertyPath;
+            _propertyToArraySize.TryGetValue(propertyKey, out var previousSize);
+
+            var currentSize = _selectableValues.arraySize;
+            if (currentSize > previousSize)
+            {
+                for (int i = previousSize; i < currentSize; i++)
+                {
+                    var element = _selectableValues.GetArrayElementAtIndex(i);
+                    var weight = element.FindPropertyRelative("_weight");
+                    weight.floatValue = currentSize == 1 && i == 0 ? 1f : 0f;
+                }
+
+                property.serializedObject.ApplyModifiedProperties();
+            }
+
+            _propertyToArraySize[propertyKey] = currentSize;
         }
     }
 }

--- a/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
+++ b/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
@@ -1,7 +1,6 @@
 #if UNITY_EDITOR
 
 using RandomElementsSystem.Types;
-using System.Collections.Generic;
 
 using UnityEditor;
 using UnityEngine;
@@ -13,7 +12,7 @@ namespace RandomElementsSystem.Editor
     {
         protected bool _isEqualWeightForAllItems;
         protected SerializedProperty _selectableValues;
-        protected readonly Dictionary<string, int> _propertyToArraySize = new();
+        private int _previousArraySize;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -130,23 +129,27 @@ namespace RandomElementsSystem.Editor
                 return;
             }
 
-            var propertyKey = property.propertyPath;
-            _propertyToArraySize.TryGetValue(propertyKey, out var previousSize);
-
             var currentSize = _selectableValues.arraySize;
-            if (currentSize > previousSize)
-            {
-                for (int i = previousSize; i < currentSize; i++)
-                {
-                    var element = _selectableValues.GetArrayElementAtIndex(i);
-                    var weight = element.FindPropertyRelative("_weight");
-                    weight.floatValue = currentSize == 1 && i == 0 ? 1f : 0f;
-                }
 
+            if (currentSize == 1)
+            {
+                var element = _selectableValues.GetArrayElementAtIndex(0);
+                var weight = element.FindPropertyRelative("_weight");
+                if (!Mathf.Approximately(weight.floatValue, 1f))
+                {
+                    weight.floatValue = 1f;
+                    property.serializedObject.ApplyModifiedProperties();
+                }
+            }
+            else if (currentSize > _previousArraySize)
+            {
+                var element = _selectableValues.GetArrayElementAtIndex(currentSize - 1);
+                var weight = element.FindPropertyRelative("_weight");
+                weight.floatValue = 0f;
                 property.serializedObject.ApplyModifiedProperties();
             }
 
-            _propertyToArraySize[propertyKey] = currentSize;
+            _previousArraySize = currentSize;
         }
     }
 }


### PR DESCRIPTION
## Summary
- track array size in the property drawer
- assign weight 1 to first item and weight 0 to later additions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73490e6d88330998bffd94107b70e