### PR TITLE
Prevent existing weights from being reset on first draw

### DIFF
--- a/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
+++ b/Assets/vodoleystudio/RandomElementsSystemDomain/Editor/SelectiveRandomWeightPropertyBasePropertyDrawer.cs
@@ -13,6 +13,7 @@ namespace RandomElementsSystem.Editor
         protected bool _isEqualWeightForAllItems;
         protected SerializedProperty _selectableValues;
         private int _previousArraySize;
+        private bool _isInitialized;
 
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -131,7 +132,14 @@ namespace RandomElementsSystem.Editor
 
             var currentSize = _selectableValues.arraySize;
 
-            if (currentSize == 1)
+            if (!_isInitialized)
+            {
+                _isInitialized = true;
+                _previousArraySize = currentSize;
+                return;
+            }
+
+            if (currentSize == 1 && _previousArraySize == 0)
             {
                 var element = _selectableValues.GetArrayElementAtIndex(0);
                 var weight = element.FindPropertyRelative("_weight");
@@ -153,5 +161,4 @@ namespace RandomElementsSystem.Editor
         }
     }
 }
-
 #endif


### PR DESCRIPTION
## Summary
- track property drawer initialization to preserve existing weights
- only apply default weight when array grows

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73ee65f408330ae156d667d9af0bf